### PR TITLE
Split stderr arg by lines

### DIFF
--- a/logger/raven_logger.py
+++ b/logger/raven_logger.py
@@ -106,7 +106,8 @@ class LoggerClient:
         if shell_args.stderr:
             # raven only accepts some number of list items
             #  but you probably want the end of the message
-            stderr_list = shell_args.stderr.splitlines()[-self._client.list_max_length:]
+            list_max_length = getattr(self._client, 'list_max_length', 50)
+            stderr_list = shell_args.stderr.splitlines()[-list_max_length:]
             extra['stderr'] = stderr_list
 
         self._client.capture('raven.events.Exception', data=data, extra=extra)

--- a/logger/raven_logger.py
+++ b/logger/raven_logger.py
@@ -104,7 +104,10 @@ class LoggerClient:
             extra['environment'] = dict([item.split('=', maxsplit=1) for item in shell_args.env.split('\n')])
 
         if shell_args.stderr:
-            extra['stderr'] = shell_args.stderr
+            # raven only accepts some number of list items
+            #  but you probably want the end of the message
+            stderr_list = shell_args.stderr.splitlines()[-self._client.list_max_length:]
+            extra['stderr'] = stderr_list
 
         self._client.capture('raven.events.Exception', data=data, extra=extra)
 


### PR DESCRIPTION
Because Sentry truncates strings at [client.max_string_length](https://docs.sentry.io/clients/python/advanced/) (default 400 {yes it says 200...})
And often the stderr may be longer than that, thus take the string split it by line and return that as a list instead.

https://sentry.io/potential-energy-labs/corsac/issues/334436004/